### PR TITLE
Adiciona cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "author": "Impulso Network",
   "private": false,
   "scripts": {
-    "start": "NODE_ENV=development parcel index.html",
-    "build": "NODE_ENV=production parcel build index.html --out-dir build --public-url ./ --no-cache"
+    "start": "cross-env NODE_ENV=development parcel index.html",
+    "build": "cross-env NODE_ENV=production parcel build index.html --out-dir build --public-url ./ --no-cache"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.0.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-plugin-react": "^7.13.0",
     "parcel-bundler": "^1.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1664,6 +1664,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3319,7 +3327,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
## Motivação

Os scripts não funcionam em ambiente Windows

## Motivo

A atribuição de variáveis de ambiente no Windows precisa ser precedida do comando `set`

## Alterações

1. [x] adiciona `cross-env` para o funcionamento da atribuição das variáveis de ambiente nos scripts funcionarem em todos os sistemas operacionais

## Resultado

```sh
yarn start              
yarn run v1.16.0
$ cross-env NODE_ENV=development parcel index.html
Server running at http://localhost:1234 
✨  Built in 14.75s.
Total precache size is about 998 kB for 3 resources.
```